### PR TITLE
Refactor edge ID retrieval for induced subgraph

### DIFF
--- a/R/Get_Induced_Subgraph.R
+++ b/R/Get_Induced_Subgraph.R
@@ -34,8 +34,8 @@ Get.Induced.Subgraph = function(g, vertices) {
     return(igraph::graph.empty(n = length(vertices), directed = igraph::is.directed(g)))
   }
 
-  pairs = utils::combn(vertices, 2)
-  ei = igraph::get.edge.ids(g, pairs)
+  pairs = t(utils::combn(vertices, 2))
+  ei = igraph::get_edge_ids(g, pairs)
   ei = ei[ei != 0]
 
   return(igraph::subgraph.edges(g, ei, delete.vertice = FALSE))


### PR DESCRIPTION
The `vp` argument of `get_edge_ids()` supplied as a matrix should be a
n times 2 matrix, not 2 times n as of igraph 2.1.5.

This is fixed in the PR.